### PR TITLE
Simplify browser routing example

### DIFF
--- a/examples/browser_routing.py
+++ b/examples/browser_routing.py
@@ -1,5 +1,7 @@
 """Example: direct-to-VM browser routing for raw HTTP."""
 
+import httpx
+
 from kernel import Kernel
 
 
@@ -7,7 +9,7 @@ def main() -> None:
     client = Kernel()
 
     browser = client.browsers.create()
-    response = client.browsers.request(browser.session_id, "GET", "https://example.com")
+    response: httpx.Response = client.browsers.request(browser.session_id, "GET", "https://example.com")
     print("status", response.status_code)
 
     client.browsers.delete_by_id(browser.session_id)

--- a/examples/browser_routing.py
+++ b/examples/browser_routing.py
@@ -10,13 +10,14 @@ def main() -> None:
 
     browser = client.browsers.create()
 
-    # Raw browser curl: streams the response. Use for large responses or when you want to stream.
+    # Raw browser curl: streams the response. Use for large responses, when you want to stream,
+    # or when you want httpx.Response semantics.
     response: httpx.Response = client.browsers.request(browser.session_id, "GET", "https://example.com")
     print("status", response.status_code)
 
     # Buffered browser curl: returns the full response in a JSON envelope. Use for small responses.
     buffered = client.browsers.curl(browser.session_id, url="https://example.com", method="GET")
-    print("buffered-status", buffered.status)
+    print("body", buffered.body)
 
     client.browsers.delete_by_id(browser.session_id)
 

--- a/examples/browser_routing.py
+++ b/examples/browser_routing.py
@@ -1,24 +1,16 @@
-"""Example: direct-to-VM browser routing for process exec and raw HTTP."""
-
-from typing import Any, cast
-
-import httpx
+"""Example: direct-to-VM browser routing for raw HTTP."""
 
 from kernel import Kernel
 
 
 def main() -> None:
-    with Kernel() as client:
-        browsers = cast(Any, client.browsers)
-        browser = browsers.create(headless=True)
-        try:
-            response = cast(httpx.Response, browsers.request(browser.session_id, "GET", "https://example.com"))
-            print("status", response.status_code)
+    client = Kernel()
 
-            with browsers.stream(browser.session_id, "GET", "https://example.com") as streamed:
-                print("streamed-bytes", len(streamed.read()))
-        finally:
-            browsers.delete_by_id(browser.session_id)
+    browser = client.browsers.create()
+    response = client.browsers.request(browser.session_id, "GET", "https://example.com")
+    print("status", response.status_code)
+
+    client.browsers.delete_by_id(browser.session_id)
 
 
 if __name__ == "__main__":

--- a/examples/browser_routing.py
+++ b/examples/browser_routing.py
@@ -9,8 +9,14 @@ def main() -> None:
     client = Kernel()
 
     browser = client.browsers.create()
+
+    # Raw browser curl: streams the response. Use for large responses or when you want to stream.
     response: httpx.Response = client.browsers.request(browser.session_id, "GET", "https://example.com")
     print("status", response.status_code)
+
+    # Buffered browser curl: returns the full response in a JSON envelope. Use for small responses.
+    buffered = client.browsers.curl(browser.session_id, url="https://example.com", method="GET")
+    print("buffered-status", buffered.status)
 
     client.browsers.delete_by_id(browser.session_id)
 


### PR DESCRIPTION
## Summary
- Drop typing casts and unused intermediate variables in examples/browser_routing.py
- Remove the streaming and try/finally blocks so it mirrors the node SDK's browser-routing example
- Verified the cleaned example runs end-to-end against production (status 200)

## Test plan
- [x] python examples/browser_routing.py prints status 200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to an example script and only adjust how it demonstrates browser request APIs and cleanup behavior.
> 
> **Overview**
> Simplifies `examples/browser_routing.py` to be a minimal browser-routing demo: removes `typing` casts, intermediate variables, and the `with`/`try/finally` streaming pattern.
> 
> The example now shows two request styles—`browsers.request` (raw `httpx.Response`) and `browsers.curl` (buffered JSON envelope)—and performs explicit session cleanup via `delete_by_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84cb2e38486f330635487ed049d692f7c9716a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->