### PR TITLE
ci: add Semgrep SAST scanning on pull requests

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,17 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: kernel/security-workflows/.github/workflows/semgrep.yml@main
+    with:
+      extra-configs: '--config p/python --config p/trailofbits'
+      codebase-description: 'Stainless-generated Python SDK for the Kernel API (public PyPI package used by customers)'
+    secrets: inherit


### PR DESCRIPTION
## Summary

Follow-up from the INC-51 postmortem ([KERNEL-1191](https://linear.app/onkernel/issue/KERNEL-1191/finalize-scope-of-repos-under-elevated-vulnerability-management)): the Kernel MCP vulnerability was missed in part because the MCP repo was not subscribed to the shared Semgrep workflow. Expanding the scope to the customer-facing SDKs so the same gap can't happen there.

This PR adds `.github/workflows/semgrep.yml` that calls the reusable workflow in [kernel/security-workflows](https://github.com/kernel/security-workflows). Runs on every PR targeting \`main\` with the agent-powered triage flow already used in \`kernel\`, \`kernel-images\`, \`cli\`, \`kernel-mcp-server\`, etc.

Semgrep configs: \`p/python\`, \`p/trailofbits\`.

Uses org-level secrets already provisioned for existing subscribers (\`CURSOR_API_KEY\`, \`CURSOR_PREFERRED_MODEL\`, \`ADMIN_APP_ID\`, \`ADMIN_APP_PRIVATE_KEY\`, \`SOCKET_API_TOKEN\`) via \`secrets: inherit\`.

### Stainless caveat

This SDK is Stainless-generated. Stainless doesn't appear to manage arbitrary files under \`.github/workflows/\`, but if the next regeneration wipes this file, we'll need to either add it to the Stainless config or restore it via a post-generation step.

## Test plan

- [ ] CI runs on this PR itself (first scan of the repo). Verify the \`Semgrep / scan\` check appears and completes.
- [ ] If findings are produced, confirm the triage agent posts comments as expected.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI workflow only, with no runtime or product code changes; main risk is PRs could fail or slow due to new scan findings or workflow instability.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/semgrep.yml`) that runs Semgrep SAST on every pull request targeting `main`.
> 
> The workflow delegates to the reusable `kernel/security-workflows` Semgrep pipeline, enables the `p/python` and `p/trailofbits` rule sets, and inherits organization secrets for automated triage/comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ea78d78e8dbd4a792e9896e17d77ccfe7bcb16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->