### PR TITLE
feat: route browser telemetry directly to the VM by default

### DIFF
--- a/examples/browser_telemetry.py
+++ b/examples/browser_telemetry.py
@@ -1,0 +1,32 @@
+"""Example: stream live browser telemetry events from a session."""
+
+from kernel import Kernel
+
+
+def main() -> None:
+    client = Kernel()
+
+    # Enable telemetry capture when creating the browser.
+    browser = client.browsers.create(telemetry={"enabled": True})
+
+    try:
+        # Telemetry is a default direct-to-VM routing subresource, so the stream
+        # connects straight to the browser VM automatically.
+        stream = client.browsers.telemetry.stream(browser.session_id)
+
+        # Make a few browser activity calls to generate events. The "api" telemetry
+        # category emits an event per VM API call, so events arrive within ~1s.
+        for _ in range(3):
+            client.browsers.curl(browser.session_id, url="https://example.com", method="GET")
+
+        # Print a few events, then stop so we don't wait on the 15s keepalive.
+        for count, message in enumerate(stream, start=1):
+            print(message.seq, message.event.type)
+            if count >= 3:
+                break
+    finally:
+        client.browsers.delete_by_id(browser.session_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kernel/_streaming.py
+++ b/src/kernel/_streaming.py
@@ -251,7 +251,12 @@ class SSEDecoder:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 
         if not line:
-            if not self._event and not self._data and not self._last_event_id and self._retry is None:
+            # Whether to dispatch depends only on what was set in the *current* block. last_event_id
+            # is sticky across events (per the SSE spec, it is intentionally not reset below), so it
+            # must not be part of this check -- otherwise, once any event carries an id, every
+            # subsequent comment-only block (e.g. a ``:\n\n`` keepalive) would dispatch an empty
+            # event, which then fails to JSON-decode in the typed Stream wrapper.
+            if not self._event and not self._data and self._retry is None:
                 return None
 
             sse = ServerSentEvent(

--- a/src/kernel/lib/browser_routing/routing.py
+++ b/src/kernel/lib/browser_routing/routing.py
@@ -41,7 +41,7 @@ _BROWSER_POOL_RELEASE_PATH = re.compile(r"^/(?:v\d+/)?browser_pools/[^/]+/releas
 def browser_routing_config_from_env() -> BrowserRoutingConfig:
     raw = os.environ.get("KERNEL_BROWSER_ROUTING_SUBRESOURCES")
     if raw is None:
-        return BrowserRoutingConfig(subresources=("curl",))
+        return BrowserRoutingConfig(subresources=("curl", "telemetry"))
     if raw.strip() == "":
         return BrowserRoutingConfig()
 

--- a/tests/test_browser_routing.py
+++ b/tests/test_browser_routing.py
@@ -98,6 +98,28 @@ def test_browser_request_uses_curl_raw() -> None:
 
 
 @respx.mock
+def test_telemetry_stream_routes_directly_to_vm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KERNEL_BROWSER_ROUTING_SUBRESOURCES", "telemetry")
+    route = respx.get("http://browser-session.test/browser/kernel/telemetry/stream").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=b'id: 1\ndata: {"category":"api"}\n\n',
+        )
+    )
+    with Kernel(base_url=base_url, api_key=api_key, _strict_response_validation=True) as client:
+        _cache_browser(client)
+        stream = client.browsers.telemetry.stream("sess-1")
+        stream.close()
+
+    assert route.called
+    request = cast(httpx.Request, cast(Any, route.calls[0]).request)
+    assert request.url.path == "/browser/kernel/telemetry/stream"
+    assert request.url.params.get("jwt") == "token-abc"
+    assert request.headers.get("Authorization") is None
+
+
+@respx.mock
 def test_browser_request_params_cannot_override_target_url_or_jwt() -> None:
     route = respx.get("http://browser-session.test/browser/kernel/curl/raw").mock(
         return_value=httpx.Response(200, content=b"ok")
@@ -315,7 +337,7 @@ def test_browser_route_from_browser_requires_base_url_and_jwt() -> None:
 
 def test_browser_routing_config_from_env_defaults_to_curl(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("KERNEL_BROWSER_ROUTING_SUBRESOURCES", raising=False)
-    assert browser_routing_config_from_env().subresources == ("curl",)
+    assert browser_routing_config_from_env().subresources == ("curl", "telemetry")
 
 
 def test_browser_routing_config_from_env_empty_string_disables_routing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -28,6 +28,32 @@ async def test_basic(sync: bool, client: Kernel, async_client: AsyncKernel) -> N
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_keepalive_comment_after_event_with_id(sync: bool, client: Kernel, async_client: AsyncKernel) -> None:
+    # A ``:`` comment frame (the server's SSE keepalive) that arrives after an event which set an
+    # id must be ignored, not dispatched as an empty event. last_event_id is sticky, so this is a
+    # regression guard against it leaking an undecodable empty frame into the typed stream.
+    def body() -> Iterator[bytes]:
+        yield b"id: 1\n"
+        yield b'data: {"foo":true}\n'
+        yield b"\n"
+        yield b":\n"
+        yield b"\n"
+        yield b'data: {"bar":false}\n'
+        yield b"\n"
+
+    iterator = make_event_iterator(content=body(), sync=sync, client=client, async_client=async_client)
+
+    sse = await iter_next(iterator)
+    assert sse.json() == {"foo": True}
+
+    sse = await iter_next(iterator)
+    assert sse.json() == {"bar": False}
+
+    await assert_empty_iter(iterator)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 async def test_data_missing_event(sync: bool, client: Kernel, async_client: AsyncKernel) -> None:
     def body() -> Iterator[bytes]:
         yield b'data: {"foo":true}\n'


### PR DESCRIPTION
## What

- **Telemetry method path** changed from `GET /browsers/{id}/telemetry` to `GET /browsers/{id}/telemetry/stream` (both sync and async) so it mirrors the browser VM endpoint. When the request is rewritten for direct-to-VM routing, the pure path passthrough yields `{base_url}/telemetry/stream` — the SSE stream on the VM. (The VM's `{base_url}/telemetry` is a *different*, non-stream JSON config endpoint, so the `/stream` suffix is required for direct routing to hit the stream.)
- **`telemetry` added to the default** `KERNEL_BROWSER_ROUTING_SUBRESOURCES` allowlist alongside `curl`, so telemetry streams route directly to the VM with no env var configuration.
- Updated `api.md` and the routing unit tests; added a unit test asserting a `telemetry.stream(...)` call rewrites to `{base_url}/telemetry/stream` with the jwt query param appended and the `Authorization` header stripped.

## Dependency / rollout note

This DEPENDS ON the control-plane PR renaming `/browsers/{id}/telemetry` -> `/browsers/{id}/telemetry/stream`. That rename is not yet deployed to prod. Until it deploys, a *non-routed* call to the new SDK path 404s in prod, while a *direct-routed* call (rewritten to `{base_url}/telemetry/stream` on the VM) works today. Direct routing is the default for telemetry, so the common path works now; this also independently proves the rewrite is doing the work.

## Live smoke evidence (prod)

Created a headless browser with telemetry enabled, opened `browsers.telemetry.stream(...)`, generated activity via `browsers.curl(...)`, and instrumented the httpx layer to record the final outbound request:

- Events observed: **1** (within ~25s; `category="api"`, `type="api_call"`, `operation_id="BrowserCurl"`)
- Routed URL host: `proxy.jfk-focused-mirzakhani.onkernel.com:8443` (the session base_url host) — NOT `api.onkernel.com`
- Path ends with `/telemetry/stream`
- `Authorization` header stripped; `jwt` query param present
- Browser deleted in `finally`

## Tests

- `uv run pytest tests/test_browser_routing.py` — 21 passed
- `uv run ruff check` on changed paths — clean
- `uv run python -c "import kernel"` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default request routing and auth stripping for telemetry SSE, with a control-plane path dependency noted in the PR; the streaming decoder fix is localized but affects all SSE consumers.
> 
> **Overview**
> **Browser telemetry** is now included in the default direct-to-VM routing allowlist (`curl` and `telemetry`), so `browsers.telemetry.stream` rewrites to the session VM with JWT query auth and no `Authorization` header unless routing is disabled via env. A new **example** and routing test cover streaming telemetry from a session.
> 
> The **SSE decoder** no longer treats sticky `last_event_id` as a reason to emit an event on comment-only keepalive blocks (`:\n\n`). That fixes idle telemetry streams dying with `JSONDecodeError` on empty frames after the first event with an `id`. A sync/async regression test was added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ee2b2653c581839be11bb29be5b68166e80658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Update — idle-stream SSE keepalive fix now included in this PR

This PR also fixes a crash on idle SSE streams. The SSE decoder's empty-block guard (`src/kernel/_streaming.py`) included `last_event_id`, which is sticky across events per the SSE spec — so once any event carried an id, every subsequent comment-only block (the server's `:\n\n` keepalive, sent every ~15s) dispatched an empty-data event that the typed `Stream` wrapper then `.json()`-decoded, raising `JSONDecodeError` and ending the stream. Dropped `last_event_id` from the guard; added a regression test (`tests/test_streaming.py`).

Note: `src/kernel/_streaming.py` is Stainless codegen-owned; this is a local patch pending an upstream fix in the generator config.