### PR TITLE
fix: don't misroute telemetry/events to the browser VM

### DIFF
--- a/src/kernel/lib/browser_routing/routing.py
+++ b/src/kernel/lib/browser_routing/routing.py
@@ -41,7 +41,10 @@ _BROWSER_POOL_RELEASE_PATH = re.compile(r"^/(?:v\d+/)?browser_pools/[^/]+/releas
 def browser_routing_config_from_env() -> BrowserRoutingConfig:
     raw = os.environ.get("KERNEL_BROWSER_ROUTING_SUBRESOURCES")
     if raw is None:
-        return BrowserRoutingConfig(subresources=("curl", "telemetry"))
+        # Path prefixes eligible for direct-to-VM routing. "telemetry/stream" is
+        # the live SSE endpoint (VM); "telemetry/events" is a historical read
+        # served by the control plane (S2) and must NOT be here.
+        return BrowserRoutingConfig(subresources=("curl", "telemetry/stream"))
     if raw.strip() == "":
         return BrowserRoutingConfig()
 
@@ -188,6 +191,21 @@ def _session_id_from_browser_pool_release_request(request: httpx.Request, path: 
     return normalized or None
 
 
+def _matches_direct_vm_prefix(tail: str, prefixes: tuple[str, ...]) -> bool:
+    """Whether tail (the path after browsers/{id}/) is covered by an allow prefix,
+    matching on segment boundaries: "telemetry/stream" matches "telemetry/stream"
+    and "telemetry/stream/...", but not "telemetry/events" or "telemetry/streamfoo".
+    Keeps historical control-plane reads (e.g. telemetry/events, served from S2)
+    off the VM.
+    """
+    tail = tail.strip("/")
+    for prefix in prefixes:
+        prefix = prefix.strip("/")
+        if prefix and (tail == prefix or tail.startswith(prefix + "/")):
+            return True
+    return False
+
+
 def rewrite_direct_vm_options(
     options: FinalRequestOptions,
     *,
@@ -199,7 +217,7 @@ def rewrite_direct_vm_options(
         return options
 
     session_id, subresource, suffix = match
-    if subresource not in set(config.subresources):
+    if not _matches_direct_vm_prefix(f"{subresource}{suffix}", config.subresources):
         return options
 
     route = cache.get(session_id)

--- a/tests/test_browser_routing.py
+++ b/tests/test_browser_routing.py
@@ -337,7 +337,23 @@ def test_browser_route_from_browser_requires_base_url_and_jwt() -> None:
 
 def test_browser_routing_config_from_env_defaults_to_curl(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("KERNEL_BROWSER_ROUTING_SUBRESOURCES", raising=False)
-    assert browser_routing_config_from_env().subresources == ("curl", "telemetry")
+    assert browser_routing_config_from_env().subresources == ("curl", "telemetry/stream")
+
+
+def test_direct_vm_routing_allowlist_segment_boundary() -> None:
+    # Pins the fix: telemetry/stream (live SSE) routes to the VM; telemetry/events
+    # (historical, served by the control plane from S2) does NOT; and a
+    # stream-prefixed-but-different path is not matched.
+    from kernel.lib.browser_routing.routing import _matches_direct_vm_prefix
+
+    prefixes = ("curl", "telemetry/stream")
+    assert _matches_direct_vm_prefix("telemetry/stream", prefixes) is True
+    assert _matches_direct_vm_prefix("telemetry/stream/x", prefixes) is True
+    assert _matches_direct_vm_prefix("telemetry/events", prefixes) is False
+    assert _matches_direct_vm_prefix("telemetry/streaming-config", prefixes) is False
+    assert _matches_direct_vm_prefix("telemetry", prefixes) is False
+    assert _matches_direct_vm_prefix("curl/raw", prefixes) is True
+    assert _matches_direct_vm_prefix("fs/read", prefixes) is False
 
 
 def test_browser_routing_config_from_env_empty_string_disables_routing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_browser_routing.py
+++ b/tests/test_browser_routing.py
@@ -99,7 +99,7 @@ def test_browser_request_uses_curl_raw() -> None:
 
 @respx.mock
 def test_telemetry_stream_routes_directly_to_vm(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("KERNEL_BROWSER_ROUTING_SUBRESOURCES", "telemetry")
+    monkeypatch.setenv("KERNEL_BROWSER_ROUTING_SUBRESOURCES", "telemetry/stream")
     route = respx.get("http://browser-session.test/browser/kernel/telemetry/stream").mock(
         return_value=httpx.Response(
             200,
@@ -354,6 +354,35 @@ def test_direct_vm_routing_allowlist_segment_boundary() -> None:
     assert _matches_direct_vm_prefix("telemetry", prefixes) is False
     assert _matches_direct_vm_prefix("curl/raw", prefixes) is True
     assert _matches_direct_vm_prefix("fs/read", prefixes) is False
+
+
+def test_rewrite_direct_vm_options_keeps_telemetry_events_on_control_plane() -> None:
+    # Integration through the real routing hook: telemetry/events (historical,
+    # control-plane/S2) must NOT be rewritten to the VM, while telemetry/stream
+    # (live SSE) must be.
+    from kernel._models import FinalRequestOptions
+    from kernel.lib.browser_routing.routing import (
+        BrowserRoute,
+        BrowserRouteCache,
+        BrowserRoutingConfig,
+        rewrite_direct_vm_options,
+    )
+
+    cache = BrowserRouteCache()
+    cache.set(
+        BrowserRoute(session_id="sess-1", base_url="http://browser-session.test/browser/kernel", jwt="token-abc")
+    )
+    config = BrowserRoutingConfig(subresources=("curl", "telemetry/stream"))
+
+    events = rewrite_direct_vm_options(
+        FinalRequestOptions(method="get", url="/browsers/sess-1/telemetry/events"), cache=cache, config=config
+    )
+    assert events.url == "/browsers/sess-1/telemetry/events"  # unchanged -> control plane
+
+    stream = rewrite_direct_vm_options(
+        FinalRequestOptions(method="get", url="/browsers/sess-1/telemetry/stream"), cache=cache, config=config
+    )
+    assert str(stream.url).startswith("http://browser-session.test/browser/kernel/telemetry/stream")
 
 
 def test_browser_routing_config_from_env_empty_string_disables_routing(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Python companion to kernel-go-sdk#126. The direct-to-VM routing allowlist matched on the subresource segment (`telemetry`), so the new historical `GET /browsers/{id}/telemetry/events` (served by the control plane from S2) was routed to the session VM (live `telemetry/stream` SSE only) once a session was route-cached → failures/wrong data.

**Fix (in `src/kernel/lib/`, Stainless-preserved → durable across regens):**
- Allowlist entries are full path-prefixes (`curl`, `telemetry/stream`), not bare subresources.
- Segment-boundary matching: `telemetry/stream` matches `telemetry/stream[/...]` but NOT `telemetry/events` or `telemetry/streamfoo`.
- Safe by default: anything not allowlisted (incl. future endpoints) → control plane.
- Adds a regression vector; updates the default-config assertion to `("curl","telemetry/stream")`.

Should land in **0.70.0**, which introduces `telemetry/events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing for browser telemetry and env defaults; wrong matching would break SSE or historical events, but scope is limited to browser_routing with strong regression tests.
> 
> **Overview**
> Fixes **misrouting** of `GET /browsers/{id}/telemetry/events` to the browser VM when a session was in the route cache. The old allowlist matched the first path segment (`telemetry`), so historical events (control plane / S2) were sent to the VM alongside live `telemetry/stream` SSE.
> 
> **Default direct-to-VM prefixes** are now `curl` and `telemetry/stream` (not bare `telemetry`). Matching uses **segment-boundary path prefixes** via `_matches_direct_vm_prefix`, so `telemetry/stream` and subpaths rewrite to the VM while `telemetry/events`, `telemetry/streamfoo`, etc. stay on the control plane.
> 
> `rewrite_direct_vm_options` applies that prefix check to the full tail after `browsers/{id}/`. Tests cover the matcher, integration for events vs stream, and updated env-default expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31a9857d89597286e5d490a61657fe8a24df2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->