### PR TITLE
test: assert stream cancellation reaches transport

### DIFF
--- a/tests/test_browser_routing.py
+++ b/tests/test_browser_routing.py
@@ -122,7 +122,7 @@ def test_telemetry_stream_routes_directly_to_vm(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
-async def test_async_telemetry_stream_cancellation_survives_direct_routing(
+async def test_async_telemetry_stream_cancellation_reaches_transport(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("KERNEL_BROWSER_ROUTING_SUBRESOURCES", "telemetry/stream")

--- a/tests/test_browser_routing.py
+++ b/tests/test_browser_routing.py
@@ -127,24 +127,25 @@ async def test_async_telemetry_stream_cancellation_survives_direct_routing(
 ) -> None:
     monkeypatch.setenv("KERNEL_BROWSER_ROUTING_SUBRESOURCES", "telemetry/stream")
     read_started = asyncio.Event()
-    read_stopped = asyncio.Event()
+    transport_cancelled = asyncio.Event()
+    chunks: asyncio.Queue[bytes] = asyncio.Queue()
 
     class BlockingSSEStream(httpx.AsyncByteStream):
         @override
         async def __aiter__(self) -> AsyncIterator[bytes]:
             read_started.set()
             try:
-                await asyncio.Event().wait()
-            finally:
-                read_stopped.set()
-            yield b""
+                while True:
+                    yield await chunks.get()
+            except asyncio.CancelledError:
+                transport_cancelled.set()
+                raise
 
         @override
         async def aclose(self) -> None:
-            read_stopped.set()
+            pass
 
-    async def handle_request(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/browser/kernel/telemetry/stream"
+    async def handle_request(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},
@@ -168,7 +169,7 @@ async def test_async_telemetry_stream_cancellation_survives_direct_routing(
         consumer.cancel()
         with pytest.raises(asyncio.CancelledError):
             await asyncio.wait_for(consumer, timeout=1)
-        await asyncio.wait_for(read_stopped.wait(), timeout=1)
+        await asyncio.wait_for(transport_cancelled.wait(), timeout=1)
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

- assert consumer cancellation reaches the transport byte stream
- remove the redundant route-path assertion and unreachable mock yield
- keep the direct-routing configuration covered without treating asyncio task cancellation as sufficient evidence

Follow-up to #148.

## Tests

- full pytest suite: 673 passed, 2732 skipped
- Pydantic v1 suite: 660 passed, 2745 skipped
- Ruff, Pyright, and mypy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to async telemetry cancellation coverage; no production or routing logic modified.
> 
> **Overview**
> **Renames** `test_async_telemetry_stream_cancellation_survives_direct_routing` to `test_async_telemetry_stream_cancellation_reaches_transport` and **tightens** what cancellation must prove for direct-routed async telemetry SSE.
> 
> The mock `BlockingSSEStream` now blocks on a chunk queue and records `asyncio.CancelledError` in `__aiter__` instead of waiting on an eternal event and signaling stop via `finally`/`aclose`. The test **waits on `transport_cancelled`** after cancelling the consumer task, so passing means cancel propagates into the httpx transport byte stream—not merely that the asyncio task was cancelled.
> 
> The mock handler **drops** the redundant path assertion (routing is covered elsewhere), and **removes** the unreachable trailing `yield` after an infinite wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d281b8f7bb61c0ab13e9a7afeec69fcc5975f2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->